### PR TITLE
Add Gulp size option to show web asset size (both uncompressed and gzipped)

### DIFF
--- a/templates/gulpfile.js
+++ b/templates/gulpfile.js
@@ -5,6 +5,7 @@ var gulp = require('gulp'),
     map = require('vinyl-map'),
     fs = require('fs'),
     path = require('path'),
+    size = require('gulp-size'),
     uri = require('URIjs'),
     s = require('underscore.string'),
     hawtio = require('hawtio-node-backend'),
@@ -27,6 +28,14 @@ var config = {
     noExternalResolve: false
   })
 };
+
+var normalSizeOptions = {
+    showFiles: true
+}, gZippedSizeOptions  = {
+    showFiles: true,
+    gzip: true
+};
+
 
 gulp.task('bower', function() {
   gulp.src('index.html')
@@ -103,8 +112,11 @@ gulp.task('template', ['tsc'], function() {
 });
 
 gulp.task('concat', ['template'], function() {
+  var gZipSize = size(gZippedSizeOptions);
   return gulp.src(['compiled.js', 'templates.js'])
     .pipe(plugins.concat(config.js))
+    .pipe(size(normalSizeOptions))
+    .pipe(gZipSize)
     .pipe(gulp.dest(config.dist));
 });
 

--- a/templates/package.json
+++ b/templates/package.json
@@ -14,6 +14,7 @@
     "gulp-notify": "^2.1.0",
     "gulp-tslint": "^1.4.2",
     "gulp-typescript": "^2.3.0",
+    "gulp-size": "^1.2.0",
     "gulp-watch": "^3.0.0",
     "through2": "^0.6.3",
     "underscore.string": "^2.4.0",


### PR DESCRIPTION
Shows web asset size as both normal and gzipped as part of the 'gulp' dev build process. This makes it easy to see how new features effect the size of the application. Plus, its just nice to know how big your plugin is without having to resort to browser tooling arithmetic.

Adds to the build output:

``` bash
[15:30:35] Starting 'concat'...
[15:30:35] hawkular-metrics.js 35.14 kB
[15:30:35] hawkular-metrics.js 6.13 kB (gzipped)
```

This should make it easier to note performance regressions. _hypothetically speaking_
